### PR TITLE
Change package name to lowercase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "ConnectThink/WP-SCSS",
+  "name": "connectthink/wp-scss",
   "description": "Compiles .scss files on your wordpress install using lefo's scssphp. Includes settings page for configuring directories, error reporting, compiling options, and auto enqueuing.",
   "keywords": ["wordpress", "plugin"],
   "type": "wordpress-plugin",

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP-SCSS
  * Plugin URI: https://github.com/ConnectThink/WP-SCSS
  * Description: Compiles scss files live on WordPress.
- * Version: 2.4.0
+ * Version: 2.4.1-beta1
  * Author: Connect Think
  * Author URI: http://connectthink.com
  * License: GPLv3


### PR DESCRIPTION
** Why are these changes being introduced:

Composer audit on this plugin flags the use of capital letters in the package name, which causes problems downstream should anyone rely on tools like composer diagnose.

** Relevant ticket(s):

Unticketed maintenance work

** How does this address that need:

This changes the package name to use only lowercase letters.

** Document any side effects to this change:

None